### PR TITLE
Better integration with upstream image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,49 +3,29 @@ FROM apol/asdk:clang
 #RUN /opt/helpers/build-cmake kirigami kde:kirigami
 
 RUN mkdir /opt/android-toolchain/
-RUN ${ANDROID_NDK_ROOT}/build/tools/make-standalone-toolchain.sh --platform=android-16 --install-dir=/opt/android-toolchain/ --force --stl=libc++
+ENV STANDALONE_CC=clang
+ENV STANDALONE_CXX=clang++
+ENV STANDALONE_EXTRA=--stl=libc++
 
-ENV PATH ${PATH}:/opt/android-toolchain/bin/
-
-ENV CC arm-linux-androideabi-clang
-ENV CXX arm-linux-androideabi-clang++
-ENV RANLIB /opt/android-toolchain/bin/arm-linux-androideabi-ranlib
-ENV LD arm-linux-androideabi-ld
-ENV AR arm-linux-androideabi-ar
-ENV CROSS_COMPILE arm-linux-androideabi
-ENV ANDROID_API 16
-ENV CFLAGS -D__ANDROID_API__=$ANDROID_API
-
-RUN sudo apt -y install autoconf libtool pkg-config
 ENV LOCAL_DEPS /opt/localdeps/
 RUN mkdir $LOCAL_DEPS
 ENV PKG_CONFIG_PATH $LOCAL_DEPS/lib/pkgconfig/
 
-WORKDIR /home/user/src/
-RUN git clone https://github.com/bitcoin-core/secp256k1
-WORKDIR secp256k1
+RUN cd && git clone https://github.com/bitcoin-core/secp256k1 --single-branch && cd secp256k1 \
+    && /opt/helpers/build-standalone "./autogen.sh && ./configure --host=${ANDROID_NDK_TOOLCHAIN_PREFIX} --disable-shared --enable-module-recovery --prefix=$LOCAL_DEPS && make -j`nproc` && make install" \
+    && cd .. && rm -rf secp256k1
 
-RUN ./autogen.sh
-RUN ./configure --host=${CROSS_COMPILE} --disable-shared --enable-module-recovery --prefix=$LOCAL_DEPS
-RUN make
-RUN sudo make install
+RUN cd && git clone https://github.com/moritz-wundke/Boost-for-Android && cd Boost-for-Android \
+    && /opt/helpers/build-standalone "./build-android.sh --arch=armeabi-v7a ${ANDROID_NDK_ROOT}" \
+    && cp -r build/out/armeabi-v7a/include/boost-1_66/boost/ $LOCAL_DEPS/include/ \
+    && cp build/out/armeabi-v7a/lib/*.a $LOCAL_DEPS/lib/ \
+    && cd .. && rm -rf Boost-For-Android
 
-WORKDIR /home/user/src/
-RUN git clone https://github.com/moritz-wundke/Boost-for-Android
-WORKDIR Boost-for-Android
-RUN ./build-android.sh --arch=armeabi-v7a ${ANDROID_NDK_ROOT}
-RUN sudo cp -r build/out/armeabi-v7a/include/boost-1_66/boost/ $LOCAL_DEPS/include/
-RUN sudo cp build/out/armeabi-v7a/lib/*.a $LOCAL_DEPS/lib/
-
-WORKDIR /home/user/src/
-RUN git clone https://github.com/libbitcoin/libbitcoin
-WORKDIR libbitcoin
-COPY libbitcoin-configure.ac-diff .
-RUN patch configure.ac < libbitcoin-configure.ac-diff
-RUN ./autogen.sh
-RUN ./configure --host=${CROSS_COMPILE} --disable-shared --with-boost=$LOCAL_DEPS --prefix=$LOCAL_DEPS
-RUN make
-RUN sudo make install
+COPY libbitcoin-configure.ac-diff /home/user/
+RUN cd && git clone https://github.com/libbitcoin/libbitcoin && cd libbitcoin \
+    && patch configure.ac < /home/user/libbitcoin-configure.ac-diff \
+    && /opt/helpers/build-standalone "./autogen.sh && ./configure --host=${ANDROID_NDK_TOOLCHAIN_PREFIX} --disable-shared --with-boost=$LOCAL_DEPS --prefix=$LOCAL_DEPS && make -j`nproc` && make install" \
+    && cd .. && rm -rf libbitcoin
 
 WORKDIR /home/user/
 


### PR DESCRIPTION
Use build-standalone script not to include the standalone build of the
library on the image. It's only useful for autotools-like builds and it
makes it considerably bigger.
Furhtermore, bundle the different builds together so we only include the
additions to /opt we require, without the intermediate steps (binary
builds, source code, etc).